### PR TITLE
Small change that reduces my memory usage with tiling.

### DIFF
--- a/engine/data_preprocessor.py
+++ b/engine/data_preprocessor.py
@@ -297,7 +297,7 @@ class Tile(BaseAugment):
             if k not in self.ignore_modalities:
                 tiled_data["image"][k] = v[
                     ..., h : h + self.output_size, w : w + self.output_size
-                ]
+                ].clone()
 
         # Place the mesaured part in the middle to help with tiling artefacts
         h_label_offset = round((self.output_size - h_labeled) / 2)
@@ -306,7 +306,7 @@ class Tile(BaseAugment):
         # Crop target to size
         tiled_data["target"] = data["target"][
             ..., h : h + self.output_size, w : w + self.output_size
-        ]
+        ].clone()
 
         # Ignore overlapping borders
         if h_index != 0:


### PR DESCRIPTION
I feel like this shouldn't be working. But I saw an improvement in my logs, so maybe someone else can check it on their setup.


My issues in #14 came from actual huge memory usage, while the GPU memory usage was somewhat low. The reason why I might experience this and others don't, is because xView2 has images of size 1024x1024, which might be bigger than other datasets.

My idea where this memory usage might come from was the following: In tiling, we load the whole image first, and then cut out a part of it. But because we're still referencing part of the memory of the big image, the garbage collector might keep the big image around, instead of only the small part that we are returning with the tiling module, which would explain the high memory usage. So I simply switched from `tile = big_image[:h, :w]` to `tile = big_image[:h, :w].clone()`, meaning that we definitely only refer to a cloned portion of the memory, which would allow the garbage collector to clean up the big image right away.

I also checked the cropping implementation of torch and they don't seem to do use cloning, so it shouldn't be necessary. However, my memory usage during the initial validation epoch went down from 55GB to 32GB, and I think I really didn't change anything else.  

Before the change:
![Before the change](https://github.com/user-attachments/assets/3c3c1cd9-f211-49fb-81c3-fec7080b9d1c)

After the change:
![After the change](https://github.com/user-attachments/assets/b49ee2c6-a6e2-437a-8b2b-b42de556be44)

Memory usage during validation is also consistently higher than during training, which would be nice to reduce, but I haven't seen any way to do that so far. 