### PR TITLE
Fix #23 Process bands based on what encoder needs

### DIFF
--- a/configs/foundation_models/croma_joint.yaml
+++ b/configs/foundation_models/croma_joint.yaml
@@ -1,0 +1,38 @@
+encoder_name: CROMA_JOINT_Encoder
+foundation_model_name: CROMA_JOINT_large
+encoder_weights: ./pretrained_models/CROMA_large.pt
+download_url: https://huggingface.co/antofuller/CROMA/resolve/main/CROMA_large.pt
+temporal_input: False
+
+
+num_layers: 24
+embed_dim: 1024
+input_size: 120  # the paper uses 120
+
+encoder_model_args:
+  size: 'large'
+  image_resolution: 120
+
+input_bands:
+  optical:
+    - B1
+    - B2
+    - B3
+    - B4
+    - B5
+    - B6
+    - B7
+    - B8
+    - B8A
+    - B9
+    - B11
+    - B12
+  sar:
+    - VV
+    - VH
+
+output_layers:
+  - 3
+  - 5
+  - 7
+  - 11

--- a/configs/foundation_models/croma_optical.yaml
+++ b/configs/foundation_models/croma_optical.yaml
@@ -27,9 +27,6 @@ input_bands:
     - B9
     - B11
     - B12
-  sar:
-    - VV
-    - VH
 
 output_layers:
   - 3

--- a/configs/foundation_models/croma_sar.yaml
+++ b/configs/foundation_models/croma_sar.yaml
@@ -1,0 +1,25 @@
+encoder_name: CROMA_SAR_Encoder
+foundation_model_name: CROMA_SAR_large
+encoder_weights: ./pretrained_models/CROMA_large.pt
+download_url: https://huggingface.co/antofuller/CROMA/resolve/main/CROMA_large.pt
+temporal_input: False
+
+
+num_layers: 24
+embed_dim: 1024
+input_size: 120  # the paper uses 120
+
+encoder_model_args:
+  size: 'large'
+  image_resolution: 120
+
+input_bands:
+  sar:
+    - VV
+    - VH
+
+output_layers:
+  - 3
+  - 5
+  - 7
+  - 11

--- a/configs/foundation_models/ssl4eo_mae_optical.yaml
+++ b/configs/foundation_models/ssl4eo_mae_optical.yaml
@@ -33,9 +33,7 @@ input_bands:
     - B10
     - B11
     - B12
-  sar:
-    - VV
-    - VH
+
 
 output_layers:
   - 3

--- a/configs/foundation_models/ssl4eo_mae_sar.yaml
+++ b/configs/foundation_models/ssl4eo_mae_sar.yaml
@@ -1,0 +1,30 @@
+encoder_name: SSL4EO_MAE_SAR_Encoder
+foundation_model_name: ssl4eo_mae_vit_small_patch16
+encoder_weights: ./pretrained_models/B2_vits16_mae_ep99.pth
+download_url: https://huggingface.co/wangyi111/SSL4EO-S12/resolve/main/B2_vits16_mae_ep99.pth
+
+temporal_input: False
+
+num_layers: 12
+embed_dim: 384
+input_size: 224
+
+encoder_model_args:
+  img_size: 224
+  in_chans: 2
+  embed_dim: 384
+  patch_size: 16
+  num_heads: 6
+  depth: 12
+  mlp_ratio: 4
+
+input_bands:
+  sar:
+    - VV
+    - VH
+
+output_layers:
+  - 3
+  - 5
+  - 7
+  - 11


### PR DESCRIPTION
Fixes #23 
- Pre-process data only for the modalities needed by the  
- Split the configs for encoders that support multi-modality
