### PR TITLE
Remove persistent workers. Fix #37

### DIFF
--- a/run.py
+++ b/run.py
@@ -255,7 +255,8 @@ def main():
             batch_size=cfg.batch_size,  # cfg.dataset["batch"],
             num_workers=cfg.num_workers,
             pin_memory=True,
-            persistent_workers=True,
+            # persistent_workers=True causes memory leak
+            persistent_workers=False,
             worker_init_fn=seed_worker,
             generator=get_generator(cfg.seed),
             drop_last=True,
@@ -268,7 +269,7 @@ def main():
             num_workers=cfg.num_workers,
             pin_memory=True,
             persistent_workers=False,
-            # worker_init_fn=seed_worker,
+            worker_init_fn=seed_worker,
             # generator=g,
             drop_last=False,
             collate_fn=collate_fn,


### PR DESCRIPTION
The system memory utilization remains stable after not using persistent_workers during training.