### PR TITLE
Fix mamba version for testing

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Create environment with mamba
       uses: conda-incubator/setup-miniconda@v3
       with:
-        mamba-version: "*"
+        mamba-version: "1.5.10"
         channels: pytorch, nvidia, conda-forge
         auto-activate-base: false
         activate-environment: gfm-bench8


### PR DESCRIPTION
Looks like the new mamba 2.0 release broke something in the testing toolchain, so I fixed it to v1.5 for now.