### PR TITLE
Install as nodep, no build isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ We provide several ways to install the dependencies.
    
    pip install -r requirements.txt
    ```
- **Then install the code repository as a package**
+ **Then install the code repository as a development package**
    ```
-   pip install -e .
+   pip install --no-build-isolation --no-deps -e .
    ```
 
 


### PR DESCRIPTION
This will install the package in a way that doesn't mess with conda, as explained here:
https://github.com/conda/conda-build/issues/4251