### PR TITLE
72 making change detection work with all models in the current version

### DIFF
--- a/configs/dataset/xview2.yaml
+++ b/configs/dataset/xview2.yaml
@@ -4,7 +4,7 @@ root_path: ./data/xView2
 download_url: https://the-dataset-is-not-publicly-available.com
 auto_download: False
 img_size: 1024
-multi_temporal: 2
+multi_temporal: False
 multi_modal: False
 
 # classes

--- a/pangaea/decoders/upernet.py
+++ b/pangaea/decoders/upernet.py
@@ -362,17 +362,20 @@ class SiamUPerNet(SegUPerNet):
             feature_multiplier=feature_multiplier,
         )
 
-    def encoder_forward(
-        self, img: dict[str, torch.Tensor]
-    ) -> list[dict[str, torch.Tensor]]:
+    def encoder_forward(self, img: dict[str, torch.Tensor]) -> list[list[torch.Tensor]]:
         if self.encoder.multi_temporal:
             # Retains the temporal dimension
             img1 = {k: v[:, :, [0], :, :] for k, v in img.items()}
             img2 = {k: v[:, :, [1], :, :] for k, v in img.items()}
 
-            # multi_temporal encoder returns features (B C T H W)
-            feat1 = self.encoder(img1).squeeze(-3)
-            feat2 = self.encoder(img2).squeeze(-3)
+            # multi_temporal encoder returns features (B C T=1 H W)
+            # or (B C T H W)
+            feat1 = self.encoder(img1)
+            feat2 = self.encoder(img2)
+
+            if self.encoder.multi_temporal_output:
+                feat1 = [f.squeeze(-3) for f in feat1]
+                feat2 = [f.squeeze(-3) for f in feat2]
 
         else:
             img1 = {k: v[:, :, 0, :, :] for k, v in img.items()}


### PR DESCRIPTION
Sets xView2 `multi_temporal: False` to make it work with Prithvi encoder after the big refactoring. xView2 represents a change detection task. Our change detection heads always encode the bi-temporal images separately and then concat or subtract the representations. So even though the dataset is bitemporal, it only presents its data as unitemporal to the encoder.

I've tested this setting with spectralgpt, satlasnet_si, ssl4eo_dino and prithvi, and it seems to work without any problems. 

Georges came up with the fix, I just changed that line and made sure that it works. 