### PR TITLE
Best checkpoint metric

### DIFF
--- a/configs/task/change_detection.yaml
+++ b/configs/task/change_detection.yaml
@@ -14,7 +14,7 @@ trainer:
   n_epochs: 80
   precision: fp32
   ckpt_interval: 20
-  eval_interval: 1
+  eval_interval: 5
   log_interval: 5
   best_metric_key: IoU
   use_wandb: ${use_wandb}

--- a/configs/task/change_detection.yaml
+++ b/configs/task/change_detection.yaml
@@ -14,8 +14,9 @@ trainer:
   n_epochs: 80
   precision: fp32
   ckpt_interval: 20
-  eval_interval: 5
-  log_interval: 5
+  eval_interval: 1
+  log_interval: 1
+  best_metric_key: IoU
   use_wandb: ${use_wandb}
 
 evaluator:

--- a/configs/task/change_detection.yaml
+++ b/configs/task/change_detection.yaml
@@ -15,7 +15,7 @@ trainer:
   precision: fp32
   ckpt_interval: 20
   eval_interval: 1
-  log_interval: 1
+  log_interval: 5
   best_metric_key: IoU
   use_wandb: ${use_wandb}
 

--- a/configs/task/regression.yaml
+++ b/configs/task/regression.yaml
@@ -16,6 +16,7 @@ trainer:
   ckpt_interval: 20
   eval_interval: 5
   log_interval: 5
+  best_metric_key: MSE
   use_wandb: ${use_wandb}
 
 evaluator:

--- a/configs/task/segmentation.yaml
+++ b/configs/task/segmentation.yaml
@@ -16,6 +16,7 @@ trainer:
   ckpt_interval: 20
   eval_interval: 5
   log_interval: 5
+  best_metric_key: mIoU
   use_wandb: ${use_wandb}
 
 evaluator:

--- a/pangaea/engine/trainer.py
+++ b/pangaea/engine/trainer.py
@@ -3,6 +3,7 @@ import operator
 import os
 import pathlib
 import time
+import numpy as np
 
 import torch
 import torch.nn as nn
@@ -30,6 +31,7 @@ class Trainer:
         ckpt_interval: int,
         eval_interval: int,
         log_interval: int,
+        best_metric_key: str,
     ):
         """Initialize the Trainer.
 
@@ -48,6 +50,7 @@ class Trainer:
             ckpt_interval (int): interval to save the checkpoint.
             eval_interval (int): interval to evaluate the model.
             log_interval (int): interval to log the training information.
+            best_metric_key (str): metric that determines best checkpoints.
         """
         self.rank = int(os.environ["RANK"])
         self.criterion = criterion
@@ -65,6 +68,7 @@ class Trainer:
         self.ckpt_interval = ckpt_interval
         self.eval_interval = eval_interval
         self.log_interval = log_interval
+        self.best_metric_key = best_metric_key
 
         self.training_stats = {
             name: RunningAverageMeter(length=self.batch_per_epoch)
@@ -72,7 +76,6 @@ class Trainer:
         }
         self.training_metrics = {}
         self.best_ckpt = None
-        self.best_metric_key = None
         self.best_metric_comp = operator.gt
 
         assert precision in [
@@ -265,7 +268,10 @@ class Trainer:
             eval_metrics (dict[float, list[float]]): metrics computed by the evaluator on the validation set.
             epoch (int): number of the epoch.
         """
-        if self.best_metric_comp(eval_metrics[self.best_metric_key], self.best_metric):
+        curr_metric = eval_metrics[self.best_metric_key]
+        if isinstance(curr_metric, list):
+            curr_metric = curr_metric[0] if self.train_loader.dataset.num_classes == 1 else np.mean(curr_metric)
+        if self.best_metric_comp(curr_metric, self.best_metric):
             self.best_metric = eval_metrics[self.best_metric_key]
             self.best_ckpt = self.get_checkpoint(epoch)
 
@@ -362,6 +368,7 @@ class SegTrainer(Trainer):
         ckpt_interval: int,
         eval_interval: int,
         log_interval: int,
+        best_metric_key: str,
     ):
         """Initialize the Trainer for segmentation task.
         Args:
@@ -379,6 +386,7 @@ class SegTrainer(Trainer):
             ckpt_interval (int): interval to save the checkpoint.
             eval_interval (int): interval to evaluate the model.
             log_interval (int): interval to log the training information.
+            best_metric_key (str): metric that determines best checkpoints.
         """
         super().__init__(
             model=model,
@@ -395,13 +403,13 @@ class SegTrainer(Trainer):
             ckpt_interval=ckpt_interval,
             eval_interval=eval_interval,
             log_interval=log_interval,
+            best_metric_key=best_metric_key,
         )
 
         self.training_metrics = {
             name: RunningAverageMeter(length=100) for name in ["Acc", "mAcc", "mIoU"]
         }
         self.best_metric = float("-inf")
-        self.best_metric_key = "mIoU"
         self.best_metric_comp = operator.gt
 
     def compute_loss(self, logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
@@ -486,6 +494,7 @@ class RegTrainer(Trainer):
         ckpt_interval: int,
         eval_interval: int,
         log_interval: int,
+        best_metric_key: str,
     ):
         """Initialize the Trainer for regression task.
         Args:
@@ -503,6 +512,7 @@ class RegTrainer(Trainer):
             ckpt_interval (int): interval to save the checkpoint.
             eval_interval (int): interval to evaluate the model.
             log_interval (int): interval to log the training information.
+            best_metric_key (str): metric that determines best checkpoints.
         """
         super().__init__(
             model=model,
@@ -519,13 +529,13 @@ class RegTrainer(Trainer):
             ckpt_interval=ckpt_interval,
             eval_interval=eval_interval,
             log_interval=log_interval,
+            best_metric_key=best_metric_key,
         )
 
         self.training_metrics = {
             name: RunningAverageMeter(length=100) for name in ["MSE"]
         }
         self.best_metric = float("inf")
-        self.best_metric_key = "MSE"
         self.best_metric_comp = operator.lt
 
     def compute_loss(self, logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:

--- a/pangaea/engine/trainer.py
+++ b/pangaea/engine/trainer.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from torch.nn import functional as F
 from torch.optim.lr_scheduler import LRScheduler
 from torch.optim.optimizer import Optimizer
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Subset
 from pangaea.utils.logger import RunningAverageMeter, sec_to_hm
 
 
@@ -77,6 +77,10 @@ class Trainer:
         self.training_metrics = {}
         self.best_ckpt = None
         self.best_metric_comp = operator.gt
+        if isinstance(self.train_loader.dataset, Subset):
+            self.num_classes = self.train_loader.dataset.dataset.num_classes
+        else:
+            self.num_classes = self.train_loader.dataset.num_classes
 
         assert precision in [
             "fp32",
@@ -270,7 +274,7 @@ class Trainer:
         """
         curr_metric = eval_metrics[self.best_metric_key]
         if isinstance(curr_metric, list):
-            curr_metric = curr_metric[0] if self.train_loader.dataset.num_classes == 1 else np.mean(curr_metric)
+            curr_metric = curr_metric[0] if self.num_classes == 1 else np.mean(curr_metric)
         if self.best_metric_comp(curr_metric, self.best_metric):
             self.best_metric = curr_metric
             self.best_ckpt = self.get_checkpoint(epoch)

--- a/pangaea/engine/trainer.py
+++ b/pangaea/engine/trainer.py
@@ -272,7 +272,7 @@ class Trainer:
         if isinstance(curr_metric, list):
             curr_metric = curr_metric[0] if self.train_loader.dataset.num_classes == 1 else np.mean(curr_metric)
         if self.best_metric_comp(curr_metric, self.best_metric):
-            self.best_metric = eval_metrics[self.best_metric_key]
+            self.best_metric = curr_metric
             self.best_ckpt = self.get_checkpoint(epoch)
 
     @torch.no_grad()


### PR DESCRIPTION
The best checkpoint metric has now been added to the task configs.

If the metric is a list of per-class values, we use the value of the foreground class when the number of classes is 1 and the average of the per-class values otherwise (as discussed).

The only awkward thing is retrieving the number of classes from the dataset. I had to include a separate clause for the limited-label scenario since the instance variable 'dataset' changes from a 'Dataset' object to a 'Subset' object when we are not training on the full dataset.