### PR TITLE
Fix encoders with inner multi_temporal_strategy when using LTAE

### DIFF
--- a/pangaea/decoders/upernet.py
+++ b/pangaea/decoders/upernet.py
@@ -302,7 +302,7 @@ class SegMTUPerNet(SegUPerNet):
     def get_decoder_in_channels(
         self, multi_temporal_strategy: str | None, encoder: Encoder
     ) -> list[int]:
-        if multi_temporal_strategy == "ltae":
+        if multi_temporal_strategy == "ltae" and encoder.multi_temporal_output:
             # if the encoder output channels vary we must use an adaptor before the LTAE
             ltae_in_channels = max(encoder.output_dim)
             if ltae_in_channels != min(encoder.output_dim):

--- a/pangaea/decoders/upernet.py
+++ b/pangaea/decoders/upernet.py
@@ -728,7 +728,7 @@ class RegMTUPerNet(RegUPerNet):
     def get_decoder_in_channels(
         self, multi_temporal_strategy: str | None, encoder: Encoder
     ) -> list[int]:
-        if multi_temporal_strategy == "ltae":
+        if multi_temporal_strategy == "ltae" and encoder.multi_temporal_output:
             # if the encoder output channels vary we must use an adaptor before the LTAE
             ltae_in_channels = max(encoder.output_dim)
             if ltae_in_channels != min(encoder.output_dim):


### PR DESCRIPTION
Error:

- Some encoders (e.g. satlasnet_mi) already merge information on the temporal dimension. Then, no multi_temporal_strategy is needed; if one is included in the configs, it will be skipped.
- When using the LTAE, the decoder input channels are changed to match LTAE output channels (LTAE only works with all inputs having the same number of channels)
- The bug was that even if the LTAE was skipped, the decoder's input channels were modified, causing shape errors.

Fix: change decoder input channels if LTAE is used AND the encoder has a multi-temporal output.
(for both SegMTUPerNet and RegMTUPerNet)